### PR TITLE
fix: Apply light theme to dialogs for visibility

### DIFF
--- a/app/src/main/res/layout/dialog_aadhar.xml
+++ b/app/src/main/res/layout/dialog_aadhar.xml
@@ -9,61 +9,65 @@
         android:padding="24dp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@drawable/login_background">
+        android:background="#F5F5F5">
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/tilName"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Name">
+            android:hint="Name"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etName"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/tilNumber"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Aadhar Number">
+            android:hint="Aadhar Number"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etNumber"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="number"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/tilDob"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Date of Birth">
+            android:hint="Date of Birth"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etDob"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="date"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/tilAddress"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Address">
+            android:hint="Address"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etAddress"
@@ -72,16 +76,17 @@
                 android:lines="3"
                 android:gravity="top"
                 android:inputType="textMultiLine"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/tilNotes"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Notes">
+            android:hint="Notes"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etNotes"
@@ -90,7 +95,7 @@
                 android:lines="3"
                 android:gravity="top"
                 android:inputType="textMultiLine"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.button.MaterialButton
@@ -99,8 +104,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:text="Upload PDF"
-            android:backgroundTint="@android:color/white"
-            android:textColor="@android:color/black"/>
+            android:text="Upload PDF"/>
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/dialog_bank.xml
+++ b/app/src/main/res/layout/dialog_bank.xml
@@ -9,164 +9,175 @@
         android:padding="24dp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@drawable/login_background">
+        android:background="#F5F5F5">
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/etTitle"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Title">
+            android:hint="Title"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/etPrivy"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Privy">
+            android:hint="Privy"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/etAccountNo"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Account No">
+            android:hint="Account No"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="number"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/etBankName"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Bank Name">
+            android:hint="Bank Name"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/etIFSC"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="IFSC Code">
+            android:hint="IFSC Code"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/etCIF"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="CIF No">
+            android:hint="CIF No"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/etUsername"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Username">
+            android:hint="Username"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/etProfilePrivy"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Profile Privy">
+            android:hint="Profile Privy"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/etMPin"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="M PIN">
+            android:hint="M PIN"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="numberPassword"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/etTPin"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="T PIN">
+            android:hint="T PIN"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="numberPassword"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/etNotes"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Notes">
+            android:hint="Notes"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:minLines="3"
                 android:gravity="top"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/dialog_card.xml
+++ b/app/src/main/res/layout/dialog_card.xml
@@ -9,120 +9,128 @@
         android:padding="24dp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@drawable/login_background">
+        android:background="#F5F5F5">
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/etBankName"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Bank Name">
+            android:hint="Bank Name"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/etCardNumber"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Card Number">
+            android:hint="Card Number"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/etCardType"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Card Type">
+            android:hint="Card Type"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/etValidTill"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Valid Till">
+            android:hint="Valid Till"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/etCVV"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="CVV">
+            android:hint="CVV"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/etCustomerId"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Customer ID">
+            android:hint="Customer ID"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/etPin"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="PIN">
+            android:hint="PIN"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="numberPassword"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/etNotes"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Notes">
+            android:hint="Notes"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:minLines="3"
                 android:gravity="top"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/dialog_license.xml
+++ b/app/src/main/res/layout/dialog_license.xml
@@ -8,44 +8,47 @@
         android:padding="24dp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@drawable/login_background">
+        android:background="#F5F5F5">
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/tilName"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Name">
+            android:hint="Name"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etName"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/tilLicenseNumber"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="License Number">
+            android:hint="License Number"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etLicenseNumber"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/tilNotes"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Notes">
+            android:hint="Notes"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etNotes"
@@ -54,7 +57,7 @@
                 android:lines="3"
                 android:gravity="top"
                 android:inputType="textMultiLine"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.button.MaterialButton
@@ -63,8 +66,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:text="Upload Document"
-            android:backgroundTint="@android:color/white"
-            android:textColor="@android:color/black"/>
+            android:text="Upload Document"/>
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/dialog_pan.xml
+++ b/app/src/main/res/layout/dialog_pan.xml
@@ -8,29 +8,31 @@
         android:padding="24dp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@drawable/login_background">
+        android:background="#F5F5F5">
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/tilName"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Name">
+            android:hint="Name"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etName"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/tilNotes"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Notes">
+            android:hint="Notes"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etNotes"
@@ -39,7 +41,7 @@
                 android:lines="3"
                 android:gravity="top"
                 android:inputType="textMultiLine"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.button.MaterialButton
@@ -48,8 +50,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:text="Upload PDF"
-            android:backgroundTint="@android:color/white"
-            android:textColor="@android:color/black"/>
+            android:text="Upload PDF"/>
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/dialog_policy.xml
+++ b/app/src/main/res/layout/dialog_policy.xml
@@ -5,104 +5,111 @@
     android:layout_height="wrap_content"
     android:orientation="vertical"
     android:padding="24dp"
-    android:background="@drawable/login_background">
+    android:background="#F5F5F5">
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/tilName"
-        style="@style/ThemedDialogInputStyle"
+        style="@style/RoundedInputStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="Policy Name">
+        android:hint="Policy Name"
+        android:textColorHint="#616161">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/etName"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textColor="@android:color/white"/>
+            android:textColor="@android:color/black"/>
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/tilAccount"
-        style="@style/ThemedDialogInputStyle"
+        style="@style/RoundedInputStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:hint="Account">
+        android:hint="Account"
+        android:textColorHint="#616161">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/etAccount"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textColor="@android:color/white"/>
+            android:textColor="@android:color/black"/>
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/tilCompany"
-        style="@style/ThemedDialogInputStyle"
+        style="@style/RoundedInputStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:hint="Company">
+        android:hint="Company"
+        android:textColorHint="#616161">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/etCompany"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textColor="@android:color/white"/>
+            android:textColor="@android:color/black"/>
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/tilNextPremiumDate"
-        style="@style/ThemedDialogInputStyle"
+        style="@style/RoundedInputStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:hint="Next Premium Date">
+        android:hint="Next Premium Date"
+        android:textColorHint="#616161">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/etNextPremiumDate"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textColor="@android:color/white"/>
+            android:textColor="@android:color/black"/>
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/tilPremiumValue"
-        style="@style/ThemedDialogInputStyle"
+        style="@style/RoundedInputStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:hint="Premium Value">
+        android:hint="Premium Value"
+        android:textColorHint="#616161">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/etPremiumValue"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textColor="@android:color/white"/>
+            android:textColor="@android:color/black"/>
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/tilMaturityValue"
-        style="@style/ThemedDialogInputStyle"
+        style="@style/RoundedInputStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:hint="Maturity Value">
+        android:hint="Maturity Value"
+        android:textColorHint="#616161">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/etMaturityValue"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textColor="@android:color/white"/>
+            android:textColor="@android:color/black"/>
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/tilNotes"
-        style="@style/ThemedDialogInputStyle"
+        style="@style/RoundedInputStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:hint="Notes">
+        android:hint="Notes"
+        android:textColorHint="#616161">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/etNotes"
@@ -110,7 +117,7 @@
             android:layout_height="wrap_content"
             android:minLines="3"
             android:gravity="top"
-            android:textColor="@android:color/white"/>
+            android:textColor="@android:color/black"/>
     </com.google.android.material.textfield.TextInputLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_voter_id.xml
+++ b/app/src/main/res/layout/dialog_voter_id.xml
@@ -8,44 +8,47 @@
         android:padding="24dp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@drawable/login_background">
+        android:background="#F5F5F5">
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/tilName"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Name">
+            android:hint="Name"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etName"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/tilVoterIdNumber"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Voter ID Number">
+            android:hint="Voter ID Number"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etVoterIdNumber"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/tilNotes"
-            style="@style/ThemedDialogInputStyle"
+            style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:hint="Notes">
+            android:hint="Notes"
+            android:textColorHint="#616161">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etNotes"
@@ -54,7 +57,7 @@
                 android:lines="3"
                 android:gravity="top"
                 android:inputType="textMultiLine"
-                android:textColor="@android:color/white"/>
+                android:textColor="@android:color/black"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.button.MaterialButton
@@ -63,8 +66,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:text="Upload Document"
-            android:backgroundTint="@android:color/white"
-            android:textColor="@android:color/black"/>
+            android:text="Upload Document"/>
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -27,15 +27,4 @@
         <item name="boxCornerRadiusBottomStart">16dp</item>
         <item name="boxCornerRadiusBottomEnd">16dp</item>
     </style>
-
-    <!-- Style for input fields in themed dialogs with dark backgrounds -->
-    <style name="ThemedDialogInputStyle" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">
-        <item name="boxCornerRadiusTopStart">16dp</item>
-        <item name="boxCornerRadiusTopEnd">16dp</item>
-        <item name="boxCornerRadiusBottomStart">16dp</item>
-        <item name="boxCornerRadiusBottomEnd">16dp</item>
-        <item name="hintTextColor">#B3FFFFFF</item> <!-- Semi-transparent white for hint -->
-        <item name="boxStrokeColor">#FFFFFF</item>
-        <item name="boxBackgroundColor">#50000000</item> <!-- Semi-transparent black background for the input area -->
-    </style>
 </resources>


### PR DESCRIPTION
Updates the UI of the 'add new record' dialogs across the app to ensure all text and input fields are clearly visible.

This change applies a light gray background to all dialogs for adding and editing records (Aadhar, Banks, Cards, etc.) and sets the text color to black. This provides a clean, high-contrast user interface and resolves the issue where text was unreadable.