### PR TITLE
Fix: Allow restoring JSON backups on fresh install

### DIFF
--- a/app/src/main/java/com/gopi/securevault/ui/backup/BackupRestoreActivity.kt
+++ b/app/src/main/java/com/gopi/securevault/ui/backup/BackupRestoreActivity.kt
@@ -62,7 +62,7 @@ class BackupRestoreActivity : AppCompatActivity() {
     private val restoreJsonLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
         if (result.resultCode == Activity.RESULT_OK) {
             result.data?.data?.also { uri ->
-                showPasswordDialog(isForDbRestore = false) { password ->
+                showPasswordPrompt { password ->
                     lifecycleScope.launch {
                         backupManager.restoreFromJson(password, uri) {
                             restartApp()
@@ -141,6 +141,25 @@ class BackupRestoreActivity : AppCompatActivity() {
                     } else {
                         Toast.makeText(this, "Incorrect password", Toast.LENGTH_SHORT).show()
                     }
+                } else {
+                    Toast.makeText(this, "Password required!", Toast.LENGTH_SHORT).show()
+                }
+            }
+            .setNegativeButton("Cancel", null)
+            .show()
+    }
+
+    private fun showPasswordPrompt(onPasswordEntered: (String) -> Unit) {
+        val dialogView = layoutInflater.inflate(R.layout.dialog_password_prompt, null)
+        val etPassword = dialogView.findViewById<android.widget.EditText>(R.id.etPassword)
+
+        AlertDialog.Builder(this)
+            .setTitle("Enter Master Password")
+            .setView(dialogView)
+            .setPositiveButton("OK") { _, _ ->
+                val password = etPassword.text.toString()
+                if (password.isNotEmpty()) {
+                    onPasswordEntered(password)
                 } else {
                     Toast.makeText(this, "Password required!", Toast.LENGTH_SHORT).show()
                 }


### PR DESCRIPTION
The backup restore functionality for `.vaultbackup` files was failing after a fresh application install. This was because the restore process was incorrectly trying to validate the user-entered password against locally stored data (in SharedPreferences) before attempting to decrypt the backup. This local data is wiped on a fresh install, causing the validation to fail and preventing the restore.

This commit fixes the issue by modifying the UI logic in `BackupRestoreActivity`. A new, simpler password prompt is introduced for restore operations. This prompt bypasses the faulty local validation and passes the entered password directly to the backend `BackupManager`.

The backend `AESUtils` encryption logic is already correctly implemented using PBKDF2 with an embedded salt, making the `.vaultbackup` files portable. This change ensures that the correct backend logic is called, allowing users to restore their backups on a new device or a fresh installation using the password the backup was created with.