### PR TITLE
feat: Add 'Misc' category and fix follow-up issues

### DIFF
--- a/app/src/main/res/layout/dialog_misc.xml
+++ b/app/src/main/res/layout/dialog_misc.xml
@@ -15,7 +15,7 @@
             style="@style/RoundedInputStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Medical/Term/Mutual Fund Name">
+            android:hint="Mutual Fund/Term /Medical Insurance">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etName"


### PR DESCRIPTION
This commit introduces a new 'Misc' (Miscellaneous) category to the application and addresses follow-up bugs and layout requests.

New "Misc" Feature:
- A new 'Misc' menu has been added to the home screen with a folder icon.
- Users can add, edit, and delete miscellaneous items. The creation dialog now includes the hint "Mutual Fund/Term /Medical Insurance" for the name field as requested.
- The new 'Misc' data is fully integrated into the `.vaultbackup` backup and restore system.
- File attachments (Upload/Download) are supported for 'Misc' items.

Bug Fixes and Layout Adjustments:
- Fixed a crash (`ActivityNotFoundException`) caused by not declaring the new `MiscActivity` in the `AndroidManifest.xml`.
- The home screen layout has been adjusted back to a 2-column grid to prevent vertical stretching of menu items, based on user feedback.
- The 'Settings' button is now centered on its own row at the bottom of the menu grid.